### PR TITLE
Fix evaluation view import and user model config

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -71,8 +71,8 @@ class LoginSerializer(serializers.Serializer):
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'spotify_id', 'display_name', 'email']  # Adjusted fields
-        read_only_fields = ['id', 'spotify_id']  # Marked fields as read-only
+        fields = ['id', 'username', 'email']  # Fields available on custom user model
+        read_only_fields = ['id']  # Marked id as read-only
 
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/django_project/settings.py
+++ b/backend/django_project/settings.py
@@ -52,6 +52,9 @@ INSTALLED_APPS = [
 
 SITE_ID = 1  # required for django‑allauth
 
+# Use custom user model defined in core app
+AUTH_USER_MODEL = 'core.User'
+
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/backend/evaluations/urls.py
+++ b/backend/evaluations/urls.py
@@ -1,14 +1,14 @@
 from django.urls import path
 from .views import (
-    EvaluationCriteriaListView,
-    EvaluationCreateView,
+    CriterionListCreateView,
+    EvaluationListCreateView,
     EvaluationTasksView,
     EvaluationSummaryView,
 )
 
 urlpatterns = [
-    path("criteria/", EvaluationCriteriaListView.as_view(), name="evaluation-criteria-list"),
-    path("create/", EvaluationCreateView.as_view(), name="evaluation-create"),
+    path("criteria/", CriterionListCreateView.as_view(), name="evaluation-criteria-list"),
+    path("create/", EvaluationListCreateView.as_view(), name="evaluation-create"),
     path("tasks/", EvaluationTasksView.as_view(), name="evaluation-tasks"),
     path("summary/", EvaluationSummaryView.as_view(), name="evaluation-summary"),
 ]


### PR DESCRIPTION
## Summary
- update evaluation URLs to use existing CriterionListCreateView and EvaluationListCreateView
- configure Django to use custom core.User model
- correct UserSerializer fields and restore profile API tests

## Testing
- `python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bcdf54cbb0832f90806d6ec8617c33