### PR TITLE
test: verify navbar renders login link

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,10 +2,19 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+jest.mock('./components/Login', () => () => <div />);
+jest.mock('./components/Register', () => () => <div />);
+jest.mock('./components/Profile', () => () => <div />);
+jest.mock('./components/ProfileForm', () => () => <div />);
+jest.mock('./components/FriendEvaluation', () => () => <div />);
+jest.mock('./components/FriendsEvaluations', () => () => <div />);
+jest.mock('./components/QuestionsFeed', () => () => <div />);
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders navbar with Login link', () => {
   render(<App />);
-  const linkElement = screen.getByTestId('learn-react-link');
+  const linkElement = screen.getByRole('link', { name: /login/i });
   expect(linkElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- replace placeholder App test with assertion that navbar renders a Login link
- mock imported components to isolate App during testing

## Testing
- `npm test -- --config jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bddb235150832fa29f20b048347850