### PR TITLE
Render personality traits arrays as readable strings

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,10 +2,19 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-test('renders learn react link', () => {
+jest.mock('./components/Login', () => () => <div />);
+jest.mock('./components/Register', () => () => <div />);
+jest.mock('./components/Profile', () => () => <div />);
+jest.mock('./components/ProfileForm', () => () => <div />);
+jest.mock('./components/FriendEvaluation', () => () => <div />);
+jest.mock('./components/FriendsEvaluations', () => () => <div />);
+jest.mock('./components/QuestionsFeed', () => () => <div />);
+
+const App = require('./App').default;
+
+test('renders navigation brand', () => {
   render(<App />);
-  const linkElement = screen.getByTestId('learn-react-link');
-  expect(linkElement).toBeInTheDocument();
+  const brand = screen.getByText('Personalities');
+  expect(brand).toBeInTheDocument();
 });

--- a/frontend/src/components/Profile.test.tsx
+++ b/frontend/src/components/Profile.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Profile from './Profile';
+import api from '../services/api';
+
+jest.mock('../services/api', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('./EvaluationSummary', () => () => <div />);
+
+describe('Profile component personality values', () => {
+  it('renders personality values for arrays and scalars', async () => {
+    (api.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        full_name: 'Test User',
+        personality_values: {
+          Trust: 'High',
+          Skills: ['Coding', 'Music'],
+        },
+      },
+    });
+
+    render(<Profile />);
+
+    const trustLabel = await screen.findByText('Trust:');
+    expect(trustLabel.parentElement).toHaveTextContent('Trust: High');
+
+    const skillsLabel = await screen.findByText('Skills:');
+    expect(skillsLabel.parentElement).toHaveTextContent(
+      'Skills: Coding, Music'
+    );
+  });
+});

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
   Alert,
 } from 'react-bootstrap';
-import api from './services/api';
+import api from '../services/api';
 import EvaluationSummary from './EvaluationSummary';  // <-- import the new component
 
 /**
@@ -345,7 +345,8 @@ const Profile: React.FC = () => {
           <ListGroup variant="flush">
             {Object.entries(personality_values).map(([trait, value]) => (
               <ListGroup.Item key={trait}>
-                <strong>{trait}:</strong> {value}
+                <strong>{trait}:</strong>{' '}
+                {Array.isArray(value) ? value.join(', ') : String(value)}
               </ListGroup.Item>
             ))}
           </ListGroup>


### PR DESCRIPTION
## Summary
- Join personality value arrays into comma-separated strings for clearer display
- Add unit tests verifying array and scalar personality value rendering
- Stub heavy components in existing App test to avoid missing dependencies

## Testing
- `npm test -- --config jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bddb2243a0832fa4baf123b7e9eea6