### PR TITLE
Remove server env import and provide test default

### DIFF
--- a/frontend/setupTests.ts
+++ b/frontend/setupTests.ts
@@ -1,2 +1,6 @@
 // setupTests.ts
 import '@testing-library/jest-dom';
+
+// Provide a default server URL for tests if none is specified
+process.env.REACT_APP_SERVER_URL =
+  process.env.REACT_APP_SERVER_URL || 'http://localhost:80';

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders navigation brand', () => {
   render(<App />);
-  const linkElement = screen.getByTestId('learn-react-link');
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/Personalities/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { io } from 'socket.io-client'; // Removed unused 'Socket' import
 import axios from 'axios';
-import '../../../server/src/config/env.js';
 // Removed unused 'FormControl' import
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,6 +1,5 @@
 import React, { useState, ChangeEvent } from 'react';
 import axios from 'axios';
-import '../../../server/src/config/env.js';
 import {
   TabContainer,
   Form,
@@ -12,6 +11,9 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
 import Alert from 'react-bootstrap/Alert';
+
+// Define server URL with a fallback for tests and development
+const SERVER_URL = process.env.REACT_APP_SERVER_URL || 'http://localhost:80';
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState<string>('');
@@ -26,7 +28,7 @@ const Login: React.FC = () => {
 
     try {
       const response = await axios.post(
-        `${process.env.REACT_APP_SERVER_URL}/api/login`,
+        `${SERVER_URL}/api/login`,
         { email, password },
         { withCredentials: true }
       );

--- a/frontend/src/components/PersonalityEvaluation.tsx
+++ b/frontend/src/components/PersonalityEvaluation.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { Container, Spinner, Alert, ListGroup } from 'react-bootstrap';
-import '../../../server/src/config/env.js';
 
 interface Evaluation {
   id: string;

--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
   Alert,
 } from 'react-bootstrap';
-import api from './services/api';
+import api from '../services/api';
 import EvaluationSummary from './EvaluationSummary';  // <-- import the new component
 
 /**
@@ -345,7 +345,7 @@ const Profile: React.FC = () => {
           <ListGroup variant="flush">
             {Object.entries(personality_values).map(([trait, value]) => (
               <ListGroup.Item key={trait}>
-                <strong>{trait}:</strong> {value}
+                <strong>{`${trait}: ${value}`}</strong>
               </ListGroup.Item>
             ))}
           </ListGroup>

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -1,7 +1,6 @@
 import React, { useState, ChangeEvent, FormEvent } from 'react';
 import axios from 'axios';
 import { Container, Form, Button, Alert } from 'react-bootstrap';
-import '../../../server/src/config/env.js';
 
 const Register: React.FC = () => {
   const [email, setEmail] = useState<string>('');


### PR DESCRIPTION
## Summary
- remove obsolete env.js imports and rely on REACT_APP_SERVER_URL
- default REACT_APP_SERVER_URL in test setup for stability
- fix Profile component import path and trait rendering
- replace legacy CRA test with navbar brand assertion

## Testing
- `npm test -- --config jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bddb1fb584832f87fe5c95e3c01332