### PR TITLE
Add drf-spectacular and configure backend CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,23 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+      - name: Run tests
+        working-directory: backend
+        run: python manage.py test

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,3 +70,4 @@ bleach==6.0.0
 # Cloudinary and Encryption
 bcrypt==4.0.1
 cloudinary==1.31.0
+drf-spectacular>=0.27


### PR DESCRIPTION
## Summary
- add drf-spectacular to backend requirements
- run pip install for backend requirements before Django tests in CI

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bde9775360832f89aaf211eba4b5b0