### PR TITLE
Use Python 3.11 in backend CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,28 @@
+---
+name: Backend CI
+
+'on':
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: python manage.py test --noinput


### PR DESCRIPTION
## Summary
- add backend CI workflow using Python 3.11 to avoid scikit-learn build issues

## Testing
- `yamllint .github/workflows/backend-ci.yml`
- `pip install scikit-learn==1.3.0`


------
https://chatgpt.com/codex/tasks/task_e_68bded50a9fc832f926e5764eaaa3317