### PR TITLE
feat: expose question vote counts and rating stats

### DIFF
--- a/backend/questions/serializers.py
+++ b/backend/questions/serializers.py
@@ -25,8 +25,10 @@ class QuestionSerializer(serializers.ModelSerializer):
     )
     question_type = serializers.ChoiceField(choices=Question.QuestionType.choices)
     options = serializers.JSONField(required=False)
-    yes_count = serializers.SerializerMethodField()
-    no_count = serializers.SerializerMethodField()
+    yes_count = serializers.IntegerField(read_only=True)
+    no_count = serializers.IntegerField(read_only=True)
+    average_rating = serializers.FloatField(read_only=True)
+    rating_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Question
@@ -41,16 +43,17 @@ class QuestionSerializer(serializers.ModelSerializer):
             "created_at",
             "yes_count",
             "no_count",
+            "average_rating",
+            "rating_count",
         ]
-        read_only_fields = ["id", "created_at", "yes_count", "no_count"]
-
-    def get_yes_count(self, obj: Question) -> int:
-        """Return the number of answers selecting index 0 (Yes)."""
-        return obj.answers.filter(selected_option_index=0).count()
-
-    def get_no_count(self, obj: Question) -> int:
-        """Return the number of answers selecting index 1 (No)."""
-        return obj.answers.filter(selected_option_index=1).count()
+        read_only_fields = [
+            "id",
+            "created_at",
+            "yes_count",
+            "no_count",
+            "average_rating",
+            "rating_count",
+        ]
 
     def validate_options(self, value):
         """

--- a/backend/questions/tests.py
+++ b/backend/questions/tests.py
@@ -1,0 +1,67 @@
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class QuestionAnswerCountTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user1 = User.objects.create_user(
+            "u1", email="u1@example.com", password="pass1234"
+        )
+        self.user2 = User.objects.create_user(
+            "u2", email="u2@example.com", password="pass1234"
+        )
+
+    def _auth(self, user):
+        self.client.force_authenticate(user=user)
+
+    def test_answer_submission_updates_counts(self):
+        """Submitting answers should update yes/no counts in subsequent fetches."""
+        self._auth(self.user1)
+        create_url = reverse("question-list-create")
+        list_url = reverse("question-list-create")
+        answer_url = reverse("answer-create")
+
+        # Create a yes/no question
+        resp = self.client.post(
+            create_url,
+            {"text": "Is this a test?", "question_type": "yesno"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        q_id = resp.data["id"]
+
+        # Initial counts should be zero
+        resp = self.client.get(list_url)
+        question = resp.data["results"][0] if "results" in resp.data else resp.data[0]
+        self.assertEqual(question["yes_count"], 0)
+        self.assertEqual(question["no_count"], 0)
+
+        # Submit a "Yes" answer as user1
+        resp = self.client.post(
+            answer_url,
+            {"question_id": q_id, "selected_option_index": 0, "is_anonymous": False},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(list_url)
+        question = resp.data["results"][0] if "results" in resp.data else resp.data[0]
+        self.assertEqual(question["yes_count"], 1)
+        self.assertEqual(question["no_count"], 0)
+
+        # Submit a "No" answer as user2
+        self._auth(self.user2)
+        resp = self.client.post(
+            answer_url,
+            {"question_id": q_id, "selected_option_index": 1, "is_anonymous": False},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(list_url)
+        question = resp.data["results"][0] if "results" in resp.data else resp.data[0]
+        self.assertEqual(question["yes_count"], 1)
+        self.assertEqual(question["no_count"], 1)

--- a/frontend/src/components/QuestionsFeed.tsx
+++ b/frontend/src/components/QuestionsFeed.tsx
@@ -29,8 +29,10 @@ interface Question {
   options?: string[] | null;
   is_anonymous: boolean;
   created_at: string;
-  yes_count: number;
-  no_count: number;
+  yes_count?: number;
+  no_count?: number;
+  average_rating?: number;
+  rating_count?: number;
 }
 
 /**
@@ -122,6 +124,13 @@ const QuestionsFeed: React.FC = () => {
         rating,
         is_anonymous: false,
       });
+      // Refresh questions to show updated rating results
+      const params: any = {};
+      if (selectedTag) params.tag = selectedTag;
+      if (search.trim()) params.search = search.trim();
+      if (sort === 'recent') params.sort = 'recent';
+      const response = await api.get('/questions/questions/', { params });
+      setQuestions(response.data.results || response.data);
     } catch (err) {
       console.error('Error submitting rating', err);
       alert('There was an error submitting your rating. Please try again.');
@@ -263,6 +272,12 @@ const QuestionsFeed: React.FC = () => {
                       className="mb-2"
                     />
                     <div className="mb-2">Rating: {ratings[q.id] || 5}</div>
+                    {typeof q.average_rating === 'number' && (
+                      <div className="mb-2">
+                        Average: {q.average_rating.toFixed(1)} (
+                        {q.rating_count ?? 0} votes)
+                      </div>
+                    )}
                     <Button
                       variant="primary"
                       onClick={() => submitRating(q.id, ratings[q.id] || 5)}
@@ -290,13 +305,13 @@ const QuestionsFeed: React.FC = () => {
                       className="me-2"
                       onClick={() => submitAnswer(q.id, 0)}
                     >
-                      Yes ({q.yes_count})
+                      Yes ({q.yes_count ?? 0})
                     </Button>
                     <Button
                       variant="outline-danger"
                       onClick={() => submitAnswer(q.id, 1)}
                     >
-                      No ({q.no_count})
+                      No ({q.no_count ?? 0})
                     </Button>
                   </>
                 )}


### PR DESCRIPTION
## Summary
- include yes/no vote counts and rating stats in question serializer
- annotate question list view with aggregate counts
- refresh counts on answer submission in frontend and show rating averages
- cover yes/no counts refresh with integration test

## Testing
- `cd backend && make test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c34bca3218832f8d4ffe8e8c1817ad