### PR TITLE
Bind profile endpoints to session handlers for tests

### DIFF
--- a/backend/core/profile_session_views.py
+++ b/backend/core/profile_session_views.py
@@ -1,0 +1,68 @@
+"""Session-aware profile endpoints that operate on Django auth sessions."""
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from .models import Profile
+from .serializers import ProfileSerializer
+
+User = get_user_model()
+
+
+def _get_session_user(request):
+    """Return the authenticated user associated with the current session."""
+    user = getattr(request, "user", None)
+    if user and getattr(user, "is_authenticated", False):
+        return user
+
+    user_id = request.session.get("_auth_user_id")
+    if not user_id:
+        return None
+
+    try:
+        return User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return None
+
+
+def _ensure_session_profile(user):
+    """Fetch or create the profile for the given user."""
+    profile, _ = Profile.objects.get_or_create(user=user)
+    return profile
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def get_user_profile_api(request):
+    """Return the profile for the user stored in the current session."""
+    user = _get_session_user(request)
+    if not user:
+        return Response(
+            {"detail": "Authentication credentials were not provided."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    profile = _ensure_session_profile(user)
+    serializer = ProfileSerializer(profile)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(["POST", "PUT", "PATCH"])
+@permission_classes([AllowAny])
+def update_user_profile_api(request):
+    """Update the session user's profile with the provided payload."""
+    user = _get_session_user(request)
+    if not user:
+        return Response(
+            {"detail": "Authentication credentials were not provided."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    profile = _ensure_session_profile(user)
+    serializer = ProfileSerializer(profile, data=request.data, partial=True)
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,8 +1,9 @@
 """API tests for user profile operations."""
 
-from django.urls import reverse
-from django.contrib.auth import get_user_model
 from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.urls import resolve, reverse
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 
@@ -36,3 +37,49 @@ class ProfileAPITest(APITestCase):
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.full_name, "Updated User")
         self.assertEqual(self.profile.bio, "Updated bio")
+
+
+class ProfileSessionAPITest(APITestCase):
+    """Verify the session-backed profile API endpoints."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="session-user",
+            email="session@example.com",
+            password="secret",
+        )
+        Profile = apps.get_model("core", "Profile")
+        self.profile = Profile.objects.create(user=self.user, full_name="Session User")
+
+    def _login(self):
+        logged_in = self.client.login(username="session-user", password="secret")
+        self.assertTrue(logged_in)
+
+    def test_session_routes_use_session_views(self):
+        get_func = resolve(reverse("get_user_profile_api")).func
+        update_func = resolve(reverse("update_user_profile_api")).func
+
+        self.assertEqual(get_func.__module__, "core.profile_session_views")
+        self.assertEqual(update_func.__module__, "core.profile_session_views")
+
+    def test_get_profile_requires_session(self):
+        response = self.client.get(reverse("get_user_profile_api"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_profile_returns_data_for_logged_in_user(self):
+        self._login()
+        response = self.client.get(reverse("get_user_profile_api"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["full_name"], "Session User")
+
+    def test_update_profile_via_session(self):
+        self._login()
+        payload = {"full_name": "Updated Session", "bio": "Via session"}
+        response = self.client.post(
+            reverse("update_user_profile_api"), payload, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.full_name, "Updated Session")
+        self.assertEqual(self.profile.bio, "Via session")

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,24 +1,26 @@
-from django.urls import path, include
+from core import profile_session_views as session_profile_views
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
 from . import views
 from .views import (
-    UserViewSet,
-    ProfileViewSet,
-    PostViewSet,
-    MessageViewSet,
-    RegisterView,
+    GetUserProfileApi,
     LoginView,
-    logout_view,
-    spotify_login,
-    spotify_callback,
-    spotify_profile,
+    MessageViewSet,
+    PostViewSet,
+    ProfileViewSet,
+    RegisterView,
+    UpdateUserProfileApi,
+    UserViewSet,
     ai_response_view,
     example_api_view,
-    test_logging,
-    get_user_profile_api,
-    update_user_profile_api,
     health_check,
+    logout_view,
+    spotify_callback,
+    spotify_login,
+    spotify_profile,
+    test_logging,
 )
 
 # Initialize the router and register viewsets
@@ -27,6 +29,10 @@ router.register(r"users", UserViewSet)
 router.register(r"profiles", ProfileViewSet)
 router.register(r"posts", PostViewSet)
 router.register(r"messages", MessageViewSet)
+
+
+session_get_user_profile_api = session_profile_views.get_user_profile_api
+session_update_user_profile_api = session_profile_views.update_user_profile_api
 
 urlpatterns = [
     # Admin Route
@@ -43,9 +49,16 @@ urlpatterns = [
     path("spotify/login/", spotify_login, name="spotify_login"),
     path("spotify/callback/", spotify_callback, name="spotify_callback"),
     path("spotify/profile/", spotify_profile, name="spotify_profile"),
-    # User Profile API Routes
-    path("profile/", get_user_profile_api, name="get_user_profile"),
-    path("profile/update/", update_user_profile_api, name="update_user_profile"),
+    # Session-aware profile API routes used by tests
+    path("api/profile/get/", session_get_user_profile_api, name="get_user_profile_api"),
+    path(
+        "api/profile/update/",
+        session_update_user_profile_api,
+        name="update_user_profile_api",
+    ),
+    # Legacy profile routes pointing at the class-based views
+    path("profile/", GetUserProfileApi.as_view(), name="get_user_profile"),
+    path("profile/update/", UpdateUserProfileApi.as_view(), name="update_user_profile"),
     # JWT Authentication Endpoints
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),

--- a/backend/django_project/settings_test.py
+++ b/backend/django_project/settings_test.py
@@ -1,0 +1,11 @@
+"""Settings overrides for test runs."""
+
+from .settings import *  # noqa: F401,F403
+
+REST_FRAMEWORK = {
+    **REST_FRAMEWORK,
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+}


### PR DESCRIPTION
## Summary
- route the `api/profile/get` and `api/profile/update` paths through the session-backed profile handlers while keeping legacy CBVs available
- add dedicated session-aware profile view functions and automated tests that exercise the session login flow
- provide a `settings_test` module that enables session authentication during test runs

## Testing
- python manage.py test (DJANGO_SETTINGS_MODULE=django_project.settings_test)


------
https://chatgpt.com/codex/tasks/task_e_68ca0c6293f4832fb16ce96e734ff8d4