### PR TITLE
Fix REST_FRAMEWORK lint violation in test settings

### DIFF
--- a/backend/django_project/settings_test.py
+++ b/backend/django_project/settings_test.py
@@ -1,0 +1,12 @@
+"""Settings overrides for test runs."""
+
+from .settings import *  # noqa: F401,F403
+from . import settings as base_settings
+
+REST_FRAMEWORK = {
+    **base_settings.REST_FRAMEWORK,
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+}


### PR DESCRIPTION
## Summary
- add a test settings module that imports the base REST_FRAMEWORK config via the settings module rather than relying on star-imported globals

## Testing
- make -C backend lint
- DJANGO_SETTINGS_MODULE=django_project.settings_test python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68ca178f614c832f8e60f1782c63e123