### PR TITLE
Improve profile update validation and visibility handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: []  # flake8 reads .flake8; no duplicates here
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/backend/userprofiles/models.py
+++ b/backend/userprofiles/models.py
@@ -114,6 +114,20 @@ class Friendship(models.Model):
     def __str__(self) -> str:
         return f"{self.from_user_id} -> {self.to_user_id}"
 
+    @classmethod
+    def are_friends(cls, u1_id: int, u2_id: int) -> bool:
+        if u1_id == u2_id:
+            return True
+        return cls.objects.filter(
+            from_user_id=u1_id,
+            to_user_id=u2_id,
+            is_confirmed=True,
+        ).exists() or cls.objects.filter(
+            from_user_id=u2_id,
+            to_user_id=u1_id,
+            is_confirmed=True,
+        ).exists()
+
 
 # Ensure privacy models are registered with the app
 try:

--- a/backend/userprofiles/models.py
+++ b/backend/userprofiles/models.py
@@ -118,15 +118,18 @@ class Friendship(models.Model):
     def are_friends(cls, u1_id: int, u2_id: int) -> bool:
         if u1_id == u2_id:
             return True
-        return cls.objects.filter(
-            from_user_id=u1_id,
-            to_user_id=u2_id,
-            is_confirmed=True,
-        ).exists() or cls.objects.filter(
-            from_user_id=u2_id,
-            to_user_id=u1_id,
-            is_confirmed=True,
-        ).exists()
+        return (
+            cls.objects.filter(
+                from_user_id=u1_id,
+                to_user_id=u2_id,
+                is_confirmed=True,
+            ).exists()
+            or cls.objects.filter(
+                from_user_id=u2_id,
+                to_user_id=u1_id,
+                is_confirmed=True,
+            ).exists()
+        )
 
 
 # Ensure privacy models are registered with the app

--- a/backend/userprofiles/privacy.py
+++ b/backend/userprofiles/privacy.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterable
 
 from django.contrib.auth import get_user_model
 
-from .models_privacy import Friendship
+from .models import Friendship
 
 User = get_user_model()
 

--- a/backend/userprofiles/serializers.py
+++ b/backend/userprofiles/serializers.py
@@ -1,15 +1,76 @@
 # userprofiles/serializers.py
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from rest_framework import serializers
 
 from .models import Profile
 
 
+PROFILE_FIELD_NAMES = [
+    "bio",
+    "profile_picture",
+    # Basic info
+    "age_group",
+    "gender_identity",
+    "pronouns",
+    "nationality",
+    "languages",
+    "location_city",
+    "location_state",
+    "location_country",
+    "zodiac_sign",
+    # Physical traits
+    "eye_color",
+    "hair_color",
+    "hair_style",
+    "height",
+    "weight",
+    "body_type",
+    "skin_tone",
+    "tattoos_piercings",
+    # Background
+    "education_level",
+    "field_of_study",
+    "profession",
+    "job_title",
+    "industry",
+    # Lifestyle & habits
+    "diet",
+    "exercise_frequency",
+    "smoking",
+    "drinking",
+    "pets",
+    # Hobbies & interests
+    "hobbies",
+    # Favorites
+    "favorite_songs",
+    "favorite_artists",
+    "favorite_books",
+    "favorite_movies",
+    "favorite_tv_shows",
+    "favorite_food",
+    "favorite_travel_destinations",
+    "favorite_sport",
+    "favorite_podcasts",
+    "favorite_influencers",
+    # Personality & values
+    "personality_values",
+    # Fun & miscellaneous
+    "fun_fact",
+    "goals",
+    "achievements",
+    "personal_quote",
+    "social_links",
+]
+
+
+UserModel = get_user_model()
+
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
-        model = User
+        model = UserModel
         fields = ["id", "username", "email"]
 
 
@@ -18,60 +79,47 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = [
-            "user",
-            "bio",
-            "profile_picture",
-            # Basic info
-            "age_group",
-            "gender_identity",
-            "pronouns",
-            "nationality",
-            "languages",
-            "location_city",
-            "location_state",
-            "location_country",
-            "zodiac_sign",
-            # Physical traits
-            "eye_color",
-            "hair_color",
-            "hair_style",
-            "height",
-            "weight",
-            "body_type",
-            "skin_tone",
-            "tattoos_piercings",
-            # Background
-            "education_level",
-            "field_of_study",
-            "profession",
-            "job_title",
-            "industry",
-            # Lifestyle & habits
-            "diet",
-            "exercise_frequency",
-            "smoking",
-            "drinking",
-            "pets",
-            # Hobbies & interests
-            "hobbies",
-            # Favorites
-            "favorite_songs",
-            "favorite_artists",
-            "favorite_books",
-            "favorite_movies",
-            "favorite_tv_shows",
-            "favorite_food",
-            "favorite_travel_destinations",
-            "favorite_sport",
-            "favorite_podcasts",
-            "favorite_influencers",
-            # Personality & values
-            "personality_values",
-            # Fun & miscellaneous
-            "fun_fact",
-            "goals",
-            "achievements",
-            "personal_quote",
-            "social_links",
-        ]
+        fields = ["user", *PROFILE_FIELD_NAMES]
+
+
+class ProfileUpdateSerializer(serializers.ModelSerializer):
+    visibility = serializers.DictField(required=False, write_only=True)
+
+    class Meta:
+        model = Profile
+        fields = [*PROFILE_FIELD_NAMES, "visibility"]
+
+    def validate_visibility(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Visibility settings must be a mapping of field names to levels.")
+
+        allowed_fields = set(PROFILE_FIELD_NAMES)
+        normalized: dict[str, str | None] = {}
+        invalid_fields = sorted(set(value.keys()) - allowed_fields)
+        if invalid_fields:
+            raise serializers.ValidationError(
+                {"fields": [f"Unknown visibility field(s): {', '.join(invalid_fields)}"]}
+            )
+
+        for key, raw_level in value.items():
+            if raw_level is None:
+                normalized[key] = None
+                continue
+            level = str(raw_level).lower()
+            if level not in {"public", "friends", "private"}:
+                raise serializers.ValidationError(
+                    {key: "Visibility level must be one of: public, friends, private."}
+                )
+            normalized[key] = level
+
+        return normalized
+
+    def validate(self, attrs):
+        allowed = set(PROFILE_FIELD_NAMES)
+        incoming_keys = set(getattr(self, "initial_data", {}).keys())
+        unknown = sorted(incoming_keys - allowed - {"visibility"})
+        if unknown:
+            raise serializers.ValidationError(
+                {field: ["This field is not recognized."] for field in unknown}
+            )
+        return super().validate(attrs)

--- a/backend/userprofiles/serializers.py
+++ b/backend/userprofiles/serializers.py
@@ -6,7 +6,6 @@ from rest_framework import serializers
 
 from .models import Profile
 
-
 PROFILE_FIELD_NAMES = [
     "bio",
     "profile_picture",
@@ -97,9 +96,7 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
         normalized: dict[str, str | None] = {}
         invalid_fields = sorted(set(value.keys()) - allowed_fields)
         if invalid_fields:
-            raise serializers.ValidationError(
-                {"fields": [f"Unknown visibility field(s): {', '.join(invalid_fields)}"]}
-            )
+            raise serializers.ValidationError({"fields": [f"Unknown visibility field(s): {', '.join(invalid_fields)}"]})
 
         for key, raw_level in value.items():
             if raw_level is None:
@@ -107,9 +104,7 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
                 continue
             level = str(raw_level).lower()
             if level not in {"public", "friends", "private"}:
-                raise serializers.ValidationError(
-                    {key: "Visibility level must be one of: public, friends, private."}
-                )
+                raise serializers.ValidationError({key: "Visibility level must be one of: public, friends, private."})
             normalized[key] = level
 
         return normalized
@@ -119,7 +114,5 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
         incoming_keys = set(getattr(self, "initial_data", {}).keys())
         unknown = sorted(incoming_keys - allowed - {"visibility"})
         if unknown:
-            raise serializers.ValidationError(
-                {field: ["This field is not recognized."] for field in unknown}
-            )
+            raise serializers.ValidationError({field: ["This field is not recognized."] for field in unknown})
         return super().validate(attrs)

--- a/backend/userprofiles/tests/conftest.py
+++ b/backend/userprofiles/tests/conftest.py
@@ -1,0 +1,21 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.apps import apps
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = PROJECT_ROOT / "backend"
+for path in (str(PROJECT_ROOT), str(BACKEND_DIR)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+backend_userprofiles = importlib.import_module("backend.userprofiles")
+sys.modules.setdefault("userprofiles", backend_userprofiles)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_project.settings")
+
+if not apps.ready:
+    django.setup()

--- a/backend/userprofiles/tests/test_privacy.py
+++ b/backend/userprofiles/tests/test_privacy.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 import pytest
 from rest_framework.test import APIClient
 
-from backend.userprofiles.models_privacy import ProfileRequest
+from userprofiles.privacy_models import InfoRequest
 
 pytestmark = pytest.mark.django_db
 User = get_user_model()
@@ -17,8 +17,8 @@ def auth_client(user):
 
 
 def test_friendship_create_and_list():
-    a = User.objects.create_user(username="a", password="x")
-    b = User.objects.create_user(username="b", password="x")
+    a = User.objects.create_user(username="a", email="a@example.com", password="x")
+    b = User.objects.create_user(username="b", email="b@example.com", password="x")
     c = auth_client(a)
     url = reverse("friendship-list")
     res = c.post(url, {"user_a": a.id, "user_b": b.id}, format="json")
@@ -30,8 +30,8 @@ def test_friendship_create_and_list():
 
 
 def test_profile_request_lifecycle():
-    owner = User.objects.create_user(username="owner", password="x")
-    req = User.objects.create_user(username="req", password="x")
+    owner = User.objects.create_user(username="owner", email="owner@example.com", password="x")
+    req = User.objects.create_user(username="req", email="req@example.com", password="x")
     c = auth_client(req)
     url = reverse("profile-request-list")
     res = c.post(url, {"owner": owner.id, "section": "favorite_movies"}, format="json")
@@ -43,7 +43,7 @@ def test_profile_request_lifecycle():
     approve_url = reverse("profile-request-approve", args=[rid])
     res = c_owner.post(approve_url)
     assert res.status_code == 200
-    assert res.data["status"] == ProfileRequest.STATUS_APPROVED
+    assert res.data["status"] == InfoRequest.STATUS_APPROVED
 
     # Requester can cancel only when pending; now it should fail
     cancel_url = reverse("profile-request-cancel", args=[rid])

--- a/backend/userprofiles/tests/test_profile_updates.py
+++ b/backend/userprofiles/tests/test_profile_updates.py
@@ -1,5 +1,6 @@
-import pytest
 from django.contrib.auth import get_user_model
+
+import pytest
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
 from userprofiles.models import Profile

--- a/backend/userprofiles/tests/test_profile_updates.py
+++ b/backend/userprofiles/tests/test_profile_updates.py
@@ -1,0 +1,90 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+
+from userprofiles.models import Profile
+from userprofiles.privacy_models import InfoRequest, ProfileVisibility
+from userprofiles.privacy_views import VisibleProfileView
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def test_update_profile_accepts_whitelisted_fields():
+    user = User.objects.create_user(username="person", email="person@example.com", password="pw")
+    client = auth_client(user)
+
+    url = "/userprofiles/profile/update/"
+    payload = {"bio": "Hello there", "hobbies": "Hiking"}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+
+    profile = Profile.objects.get(user=user)
+    assert profile.bio == "Hello there"
+    assert profile.hobbies == "Hiking"
+    assert response.data["bio"] == "Hello there"
+    assert response.data["hobbies"] == "Hiking"
+
+
+def test_update_profile_rejects_unknown_fields():
+    user = User.objects.create_user(username="reject", email="reject@example.com", password="pw")
+    client = auth_client(user)
+
+    url = "/userprofiles/profile/update/"
+    response = client.post(url, {"unknown_field": "nope"}, format="json")
+
+    assert response.status_code == 400
+    assert "unknown_field" in response.data
+
+
+def test_update_profile_updates_visibility_settings():
+    user = User.objects.create_user(username="visible", email="visible@example.com", password="pw")
+    client = auth_client(user)
+
+    url = "/userprofiles/profile/update/"
+    payload = {"visibility": {"bio": "Public", "hobbies": "private"}}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+
+    profile = Profile.objects.get(user=user)
+    visibility = ProfileVisibility.objects.get(profile=profile)
+    assert visibility.data == {"bio": "public", "hobbies": "private"}
+
+
+def test_visible_profile_respects_private_fields_and_approvals():
+    owner = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+    viewer = User.objects.create_user(username="viewer", email="viewer@example.com", password="pw")
+
+    profile = Profile.objects.create(user=owner, bio="Keep secret", hobbies="Reading")
+    ProfileVisibility.objects.create(profile=profile, data={"bio": "private", "hobbies": "friends"})
+
+    factory = APIRequestFactory()
+    request = factory.get("/visible/", {"user_id": owner.id})
+    force_authenticate(request, user=viewer)
+
+    response = VisibleProfileView.as_view()(request)
+    assert response.status_code == 200
+    assert "bio" not in response.data
+    assert "hobbies" not in response.data
+
+    InfoRequest.objects.create(
+        owner=owner,
+        requester=viewer,
+        section_key="bio",
+        status=InfoRequest.STATUS_APPROVED,
+    )
+
+    request = factory.get("/visible/", {"user_id": owner.id})
+    force_authenticate(request, user=viewer)
+    response = VisibleProfileView.as_view()(request)
+    assert response.status_code == 200
+    assert response.data.get("bio") == "Keep secret"


### PR DESCRIPTION
## Summary
- add a serializer-backed whitelist for profile updates along with visibility payload validation
- persist ProfileVisibility changes and tighten VisibleProfileView filtering using existing privacy helpers
- add pytest coverage and shared Django test setup for profile updates and visibility rules

## Testing
- pytest backend/userprofiles/tests/test_profile_updates.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cd9f23df1c832fac7e82f61d845152