### PR TITLE
Enhance evaluation normalization and gating

### DIFF
--- a/backend/evaluations/create_views.py
+++ b/backend/evaluations/create_views.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
-
 from django.apps import apps
+from django.conf import settings
 from django.db import transaction
 
 from rest_framework.permissions import IsAuthenticated
@@ -117,10 +116,7 @@ class EvaluationCreateV2View(APIView):
         # Participation gating for SUBJECT (rated user): count their outbound ratings
         outbound_count = Evaluation.objects.filter(**{f"{rater_field}_id": subject_id}).count()
 
-        try:
-            min_outbound = int(os.environ.get("DJANGO_EVAL_MIN_OUTBOUND", "10"))
-        except ValueError:
-            min_outbound = 10
+        min_outbound = int(getattr(settings, "EVALUATIONS_MIN_OUTBOUND", 10))
 
         status_value = EvaluationMeta.STATUS_ACTIVE if outbound_count >= min_outbound else EvaluationMeta.STATUS_PENDING
         EvaluationMeta.objects.create(evaluation=ev, status=status_value)

--- a/backend/evaluations/signals.py
+++ b/backend/evaluations/signals.py
@@ -81,6 +81,8 @@ def _compute_weights_for_rater(rater_id: int) -> None:
         objectivity_score=objectivity,
         pending=False,
     )
+
+
 def _handle_weight_refresh(instance: Evaluation) -> None:
     """Shared helper to refresh rater weights for a saved evaluation."""
 

--- a/backend/evaluations/tests.py
+++ b/backend/evaluations/tests.py
@@ -7,7 +7,9 @@ from django.utils import timezone
 
 from rest_framework.test import APITestCase
 
+from evaluations.meta_models import EvaluationMeta
 from evaluations.models import Criterion, Evaluation
+from evaluations.rater_models import RaterStats
 from evaluations.views import REPEAT_DAYS
 from userprofiles.models import Friendship
 
@@ -153,10 +155,142 @@ class EvaluationWeightsTests(APITestCase):
         Evaluation.objects.filter(score=4).update(reliability_weight=1.0, extreme_rate_weight=1.0)
         Evaluation.objects.filter(score=2).update(reliability_weight=0.5, extreme_rate_weight=0.5)
 
+        high_eval = Evaluation.objects.get(score=4)
+        low_eval = Evaluation.objects.get(score=2)
+        EvaluationMeta.objects.create(
+            evaluation=high_eval,
+            status=EvaluationMeta.STATUS_ACTIVE,
+        )
+        EvaluationMeta.objects.create(
+            evaluation=low_eval,
+            status=EvaluationMeta.STATUS_ACTIVE,
+        )
+
+        # Normalize the scores manually so the summary can verify aggregation logic.
+        Evaluation.objects.filter(pk=high_eval.pk).update(normalized_score=1.0)
+        Evaluation.objects.filter(pk=low_eval.pk).update(normalized_score=-1.0)
+
         response = self.client.get(reverse("evaluations:evaluation-summary-v2"))
         self.assertEqual(response.status_code, 200)
 
         payload = response.data["results"]
         self.assertEqual(len(payload), 1)
         self.assertAlmostEqual(payload[0]["weighted_average"], 3.6)
+        self.assertAlmostEqual(payload[0]["normalized_average"], 0.6)
         self.assertEqual(payload[0]["raw_count"], 2)
+
+
+class EvaluationCreateNormalizationTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.rater = User.objects.create_user(username="primary", email="r1@example.com", password="pw")
+        self.subject = User.objects.create_user(username="subject", email="subject@example.com", password="pw")
+        self.other_subject = User.objects.create_user(username="other", email="other@example.com", password="pw")
+        self.criterion = Criterion.objects.create(name="Reliability")
+
+    def _auth(self):
+        self.client.force_authenticate(user=self.rater)
+
+    def test_normalization_and_rater_stats(self):
+        self._auth()
+        url = reverse("evaluation-create") + f"?subject_id={self.subject.id}"
+
+        first_payload = {
+            "subject_id": self.subject.id,
+            "criterion_id": self.criterion.id,
+            "score": 4,
+        }
+        response = self.client.post(url, first_payload)
+        self.assertEqual(response.status_code, 201)
+
+        first_eval = Evaluation.objects.get(evaluator=self.rater, subject=self.subject)
+        self.assertAlmostEqual(first_eval.rater_mean, 4.0)
+        self.assertAlmostEqual(first_eval.rater_stddev, 0.0)
+        self.assertAlmostEqual(first_eval.normalized_score, 0.0)
+
+        second_payload = {
+            "subject_id": self.other_subject.id,
+            "criterion_id": self.criterion.id,
+            "score": 2,
+        }
+        second_url = reverse("evaluation-create") + f"?subject_id={self.other_subject.id}"
+        response = self.client.post(second_url, second_payload)
+        self.assertEqual(response.status_code, 201)
+
+        evals = Evaluation.objects.filter(evaluator=self.rater).order_by("id")
+        self.assertEqual(evals.count(), 2)
+
+        expected_mean = 3.0
+        expected_std = 1.0
+        self.assertTrue(all(abs(ev.rater_mean - expected_mean) < 1e-6 for ev in evals))
+        self.assertTrue(all(abs(ev.rater_stddev - expected_std) < 1e-6 for ev in evals))
+
+        normalized_scores = sorted(round(ev.normalized_score, 3) for ev in evals)
+        self.assertEqual(normalized_scores, [-1.0, 1.0])
+
+        stats = RaterStats.objects.get(user=self.rater)
+        self.assertEqual(stats.ratings_count, 2)
+        self.assertAlmostEqual(stats.mean_score, expected_mean)
+        self.assertAlmostEqual(stats.std_score, expected_std)
+        self.assertAlmostEqual(stats.extreme_rate, 0.0)
+        self.assertGreater(stats.reliability, 0.0)
+
+
+class EvaluationMetaGatingTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.rater = User.objects.create_user(username="rater", email="rater@example.com", password="pw")
+        self.subject = User.objects.create_user(username="subject", email="subject2@example.com", password="pw")
+        self.peer = User.objects.create_user(username="peer", email="peer@example.com", password="pw")
+        self.criterion = Criterion.objects.create(name="Generosity")
+
+    def _auth(self):
+        self.client.force_authenticate(user=self.rater)
+
+    @override_settings(EVALUATIONS_MIN_OUTBOUND=2)
+    def test_gating_transitions_from_pending_to_active(self):
+        self._auth()
+        url = reverse("evaluation-create") + f"?subject_id={self.subject.id}"
+        payload = {
+            "subject_id": self.subject.id,
+            "criterion_id": self.criterion.id,
+            "score": 3,
+        }
+        response = self.client.post(url, payload)
+        self.assertEqual(response.status_code, 201)
+
+        evaluation = Evaluation.objects.get(evaluator=self.rater, subject=self.subject)
+        meta = EvaluationMeta.objects.get(evaluation=evaluation)
+        self.assertEqual(meta.status, EvaluationMeta.STATUS_PENDING)
+
+        # Allow another evaluation past the cooldown window.
+        Evaluation.objects.filter(pk=evaluation.pk).update(
+            created_at=timezone.now() - timedelta(days=REPEAT_DAYS + 1)
+        )
+
+        # Subject submits two outbound evaluations to satisfy the threshold.
+        Evaluation.objects.create(
+            evaluator=self.subject,
+            subject=self.rater,
+            criterion=self.criterion,
+            score=4,
+        )
+        Evaluation.objects.create(
+            evaluator=self.subject,
+            subject=self.peer,
+            criterion=self.criterion,
+            score=5,
+        )
+
+        # New evaluation after threshold should be active, and prior pending metas should update.
+        second_payload = {
+            "subject_id": self.subject.id,
+            "criterion_id": self.criterion.id,
+            "score": 4,
+        }
+        response = self.client.post(url, second_payload)
+        self.assertEqual(response.status_code, 201)
+
+        metas = EvaluationMeta.objects.filter(evaluation__subject=self.subject)
+        self.assertTrue(metas.exists())
+        self.assertTrue(all(m.status == EvaluationMeta.STATUS_ACTIVE for m in metas))

--- a/backend/evaluations/tests.py
+++ b/backend/evaluations/tests.py
@@ -264,9 +264,7 @@ class EvaluationMetaGatingTests(APITestCase):
         self.assertEqual(meta.status, EvaluationMeta.STATUS_PENDING)
 
         # Allow another evaluation past the cooldown window.
-        Evaluation.objects.filter(pk=evaluation.pk).update(
-            created_at=timezone.now() - timedelta(days=REPEAT_DAYS + 1)
-        )
+        Evaluation.objects.filter(pk=evaluation.pk).update(created_at=timezone.now() - timedelta(days=REPEAT_DAYS + 1))
 
         # Subject submits two outbound evaluations to satisfy the threshold.
         Evaluation.objects.create(

--- a/backend/evaluations/views.py
+++ b/backend/evaluations/views.py
@@ -215,11 +215,7 @@ class EvaluationCreateView(APIView):
         # Evaluate outbound gating for the subject being rated.
         min_outbound = int(getattr(settings, "EVALUATIONS_MIN_OUTBOUND", 10))
         outbound_count = Evaluation.objects.filter(evaluator_id=subject_id).count()
-        status_value = (
-            EvaluationMeta.STATUS_ACTIVE
-            if outbound_count >= min_outbound
-            else EvaluationMeta.STATUS_PENDING
-        )
+        status_value = EvaluationMeta.STATUS_ACTIVE if outbound_count >= min_outbound else EvaluationMeta.STATUS_PENDING
 
         meta, created = EvaluationMeta.objects.get_or_create(
             evaluation=evaluation,

--- a/backend/evaluations/views.py
+++ b/backend/evaluations/views.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import math
 import os as _os
 import random
 from datetime import timedelta
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Avg, Max
 from django.utils import timezone
@@ -15,8 +17,11 @@ from rest_framework.views import APIView
 
 from userprofiles.models import Friendship
 
+from .meta_models import EvaluationMeta
 from .models import Criterion, Evaluation
+from .rater_models import RaterStats
 from .serializers import CriterionSerializer, EvaluationSerializer
+from .signals import evaluation_submitted
 
 # Backwards-compat constant for tests
 try:  # noqa: SIM105
@@ -153,6 +158,82 @@ class EvaluationCreateView(APIView):
             create_kwargs["familiarity"] = familiarity
 
         evaluation = Evaluation.objects.create(**create_kwargs)
+
+        # Notify downstream listeners so reliability/objectivity are recalculated.
+        evaluation_submitted.send(sender=Evaluation, evaluation=evaluation)
+
+        # Recompute normalization statistics for this evaluator.
+        rater_evaluations = list(Evaluation.objects.filter(evaluator=user))
+        scores = [float(ev.score) for ev in rater_evaluations]
+        count = len(scores)
+
+        if count:
+            mean_score = sum(scores) / count
+            if count > 1:
+                variance = sum((s - mean_score) ** 2 for s in scores) / count
+                std_score = math.sqrt(variance)
+            else:
+                std_score = 0.0
+        else:  # pragma: no cover - defensive guard
+            mean_score = 0.0
+            std_score = 0.0
+
+        normalized_denominator = std_score if std_score > 0 else None
+        for ev in rater_evaluations:
+            ev.rater_mean = mean_score
+            ev.rater_stddev = std_score
+            if normalized_denominator:
+                ev.normalized_score = (float(ev.score) - mean_score) / normalized_denominator
+            else:
+                ev.normalized_score = 0.0
+
+        if rater_evaluations:
+            Evaluation.objects.bulk_update(
+                rater_evaluations,
+                ["rater_mean", "rater_stddev", "normalized_score"],
+            )
+
+        # Persist/update rater statistics.
+        if rater_evaluations:
+            stats, _ = RaterStats.objects.get_or_create(user=user)
+            extreme_count = sum(1 for s in scores if s <= 1.0 or s >= 5.0)
+            stats.ratings_count = count
+            stats.mean_score = mean_score
+            stats.std_score = std_score
+            stats.extreme_rate = (extreme_count / count) if count else 0.0
+
+            reliability_agg = (
+                Evaluation.objects.filter(evaluator=user)
+                .exclude(reliability_weight__isnull=True)
+                .aggregate(avg_rel=Avg("reliability_weight"))
+            )
+            avg_rel = reliability_agg.get("avg_rel")
+            if avg_rel is not None:
+                stats.reliability = float(avg_rel)
+            stats.save()
+
+        # Evaluate outbound gating for the subject being rated.
+        min_outbound = int(getattr(settings, "EVALUATIONS_MIN_OUTBOUND", 10))
+        outbound_count = Evaluation.objects.filter(evaluator_id=subject_id).count()
+        status_value = (
+            EvaluationMeta.STATUS_ACTIVE
+            if outbound_count >= min_outbound
+            else EvaluationMeta.STATUS_PENDING
+        )
+
+        meta, created = EvaluationMeta.objects.get_or_create(
+            evaluation=evaluation,
+            defaults={"status": status_value},
+        )
+        if not created and meta.status != status_value:
+            meta.status = status_value
+            meta.save(update_fields=["status"])
+
+        if status_value == EvaluationMeta.STATUS_ACTIVE:
+            EvaluationMeta.objects.filter(
+                evaluation__subject_id=subject_id,
+                status=EvaluationMeta.STATUS_PENDING,
+            ).update(status=EvaluationMeta.STATUS_ACTIVE)
 
         return Response({"id": evaluation.id}, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## Summary
- compute evaluator normalization metrics and emit the evaluation_submitted signal when creating ratings
- persist rater statistics, manage EvaluationMeta gating, and reuse configuration-driven outbound thresholds
- update the weighted summary to honour normalized data while filtering by active evaluations and extend tests for normalization, gating, and cooldown behaviour

## Testing
- python manage.py test evaluations

------
https://chatgpt.com/codex/tasks/task_e_68cdac8625d8832fbd6a6e0c8e72c1e7